### PR TITLE
Add ap2en module to the setup.py file so it gets installed too.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='transcriptic',
     version='1.3.13',
-    py_modules=['transcriptic'],
+    py_modules=['transcriptic', 'ap2en'],
     install_requires=[
         'Click>=5.1',
         'requests'


### PR DESCRIPTION
This fixes the ImportError on the ap2en module when using the transcriptic command.
