### PR TITLE
Fix security issue when parsing autoprotocol in ap2en

### DIFF
--- a/ap2en.py
+++ b/ap2en.py
@@ -18,9 +18,9 @@ class AutoprotocolParser(object):
         parsed_output = []
         for i in self.instructions:
             try:
-                output = eval("self." + i['op'])(i)
+                output = getattr(self, i['op'])(i)
                 parsed_output.extend(output) if isinstance(output, list) else parsed_output.append(output)
-            except NameError:
+            except AttributeError:
                 parsed_output.append("[Unknown instruction]")
         for i, p in enumerate(parsed_output):
             print "%d. %s" % (i+1, p)


### PR DESCRIPTION
Replaced eval() with getattr() to avoid possible attacks through malicious autoprotocol files.

Consider following very simple example. It'll error out at the end, but after executing the code defined in the autoprotocol.

```
$ cat autoprotocol.json
{
  "refs": {
    "plate": {
      "new": "96-pcr", 
      "store": {
        "where": "cold_4"
      }
    }
  }, 
  "instructions": [
    {
      "object": "plate",
      "dataref": "my_image",
      "mode": "top",
      "op": "image_plate(__import__('os').system('echo This should not work!'))"
    }
  ]
}
$ cat autoprotocol.json | transcriptic summarize
This should not work!
Traceback (most recent call last):
    [...]
TypeError: 'int' object has no attribute '__getitem__'
```
